### PR TITLE
visually separate address 'box' on event page from rest of content

### DIFF
--- a/scss/modules/field.scss
+++ b/scss/modules/field.scss
@@ -129,3 +129,15 @@
 figure.align-left {
     margin: 0 1rem 0 0;;
 }
+
+
+.field.field--name-field-address.field--type-address {
+  margin: 1rem 0 0 0;
+  padding: .5rem;
+  background: $subtle-grey-01;
+  
+	.field__label {
+	  font-weight: bold;
+	}  
+}
+

--- a/scss/modules/field.scss
+++ b/scss/modules/field.scss
@@ -101,6 +101,18 @@
   }
 }
 
+.node--type-event {
+  .field.field--name-field-address.field--type-address {
+    margin: 1rem 0 0 0;
+    padding: .5rem;
+    background: $subtle-grey-01;
+
+    .field__label {
+      font-weight: bold;
+    }  
+  }
+}
+
 @media (min-width: #{$screen-sm-min}) {
   .node--type-clarin-centre {
     .field--name-field-administrative-contact, .field--name-field-technical-contact,
@@ -129,15 +141,3 @@
 figure.align-left {
     margin: 0 1rem 0 0;;
 }
-
-
-.field.field--name-field-address.field--type-address {
-  margin: 1rem 0 0 0;
-  padding: .5rem;
-  background: $subtle-grey-01;
-  
-	.field__label {
-	  font-weight: bold;
-	}  
-}
-


### PR DESCRIPTION
# Example:

----

## Before
![image](https://github.com/user-attachments/assets/4f87d8f4-528c-4990-829e-91550db4f99b)

----

## After
![image](https://github.com/user-attachments/assets/2c6b2dec-ef14-404b-8a26-ea27abf95849)

----